### PR TITLE
fix small angle in pieplot

### DIFF
--- a/sample/pieplotdemos.cpp
+++ b/sample/pieplotdemos.cpp
@@ -23,9 +23,9 @@ public:
     virtual Chart *Create()
     {
       // serie pieplot data
-      double data[] = {1.0, 2.0, 3.0} ;
-      wxString categories[] = {_("cat 1"), _("cat 2"), _("cat 3")};
-      wxColour colours[] = {wxColour(0x99, 0xCC, 0xFF), wxColour(0xFF, 0xFF, 0x99), wxColour(0x3D, 0xEB, 0x3D)} ;
+      double data[] = {1.0, 2.0, 3.0, 0.0000175};
+      wxString categories[] = {_("cat 1"), _("cat 2"), _("cat 3"), _("cat 4")};
+      wxColour colours[] = {wxColour(0x99, 0xCC, 0xFF), wxColour(0xFF, 0xFF, 0x99), wxColour(0x3D, 0xEB, 0x3D), wxColour(0xFF, 0x00, 0x00)} ;
 
       ColorScheme* colorScheme = new ColorScheme(colours, WXSIZEOF(colours));
 

--- a/src/pie/pieplot.cpp
+++ b/src/pie/pieplot.cpp
@@ -201,8 +201,9 @@ void PiePlot::DrawData(ChartDC& cdc, wxRect rc)
         double angle2 = 360 * part;
 
         dc.SetBrush(*wxTheBrushList->FindOrCreateBrush(m_colorScheme.GetColor(n)));
-
-        dc.DrawEllipticArc(x0, y0, radHoriz, radVert, angle1, angle2);
+        if(abs(angle2 - angle1) > 0.003) {
+          dc.DrawEllipticArc(x0, y0, radHoriz, radVert, angle1, angle2);
+        }
     }
 
     // draw edges


### PR DESCRIPTION
* When a pie part was very small (somewhere between 0.002 and 0.003), all previous parts were coloured the colour of this small part.
* Adjusted demo with a small part that coloured the whole pie red.