### PR TITLE
Fix non-default colour in gantt and bar plots.

### DIFF
--- a/src/bars/barrenderer.cpp
+++ b/src/bars/barrenderer.cpp
@@ -257,7 +257,8 @@ AreaDraw *BarRenderer::GetBarDraw(size_t serie)
     if (barDraw == NULL) 
     {
         // barDraw = new FillAreaDraw(GetDefaultColour(serie), GetDefaultColour(serie));
-        barDraw = new FillAreaDraw(*wxTRANSPARENT_PEN, GetDefaultColour(serie));
+        // barDraw = new FillAreaDraw(*wxTRANSPARENT_PEN, GetDefaultColour(serie));
+        barDraw = new FillAreaDraw(*wxTRANSPARENT_PEN, GetSerieColour(serie));
 
         m_barDraws.SetAreaDraw(serie, barDraw);
     }

--- a/src/gantt/ganttrenderer.cpp
+++ b/src/gantt/ganttrenderer.cpp
@@ -63,8 +63,10 @@ AreaDraw *GanttRenderer::GetSerieDraw(size_t serie)
 {
     AreaDraw *serieDraw = m_serieDraws.GetAreaDraw(serie);
     if (serieDraw == NULL) {
+        // serieDraw = new FillAreaDraw(*wxBLACK_PEN,
+        //         *wxTheBrushList->FindOrCreateBrush(GetDefaultColour(serie), wxBRUSHSTYLE_SOLID));
         serieDraw = new FillAreaDraw(*wxBLACK_PEN,
-                *wxTheBrushList->FindOrCreateBrush(GetDefaultColour(serie), wxBRUSHSTYLE_SOLID));
+                *wxTheBrushList->FindOrCreateBrush(GetSerieColour(serie), wxBRUSHSTYLE_SOLID));
         m_serieDraws.SetAreaDraw(serie, serieDraw);
     }
     return serieDraw;


### PR DESCRIPTION
Fix for adding non-default colours to datasets in gantt and bar charts.
Fixes #54 